### PR TITLE
Remove FullName Validation from ApplicationUserConfiguration file.

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,6 +1,8 @@
-﻿using ELProject.Domain.Models;
+﻿using ELProject.DataAccess.Repositories.Repos;
+using ELProject.Domain.Models;
 using ELProject.Shared;
 using ELProject.Shared.DTOs;
+using Google.Apis.Auth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -18,19 +20,22 @@ namespace ELProject.Controllers
     {
         private readonly UserManager<ApplicationUser> userManager;
         private readonly IConfiguration config;
+        private readonly AuthRepository authRepo;
         private readonly IFileStorageService fileStorageService;
 
         public AuthController(UserManager<ApplicationUser> _userManager, 
-            IConfiguration _config, 
+            IConfiguration _config,
+            AuthRepository _authRepo,
             IFileStorageService _fileStorageService)
         {
             userManager = _userManager; // To access User and Role Tables in Db
             config = _config; // To access appsettings.json
+            authRepo = _authRepo; // To Access GetTokenAsync Method
             fileStorageService = _fileStorageService;
             // To save profile image file on server (or cloud) and return its path to store in DB
         }
 
-        [HttpPost("Register")] // api/Account/Register
+        [HttpPost("Register")] // api/Auth/Register
         public async Task<IActionResult> Register([FromForm]RegisterDto UserDto)
         {
             if (ModelState.IsValid)
@@ -65,7 +70,7 @@ namespace ELProject.Controllers
         }
 
 
-        [HttpPost("Login")] // api/Account/Login
+        [HttpPost("Login")] // api/Auth/Login
         public async Task<IActionResult> Login(LoginDto userFromRequest)
         {
             if (ModelState.IsValid)
@@ -79,46 +84,42 @@ namespace ELProject.Controllers
 
                     if (isValid)
                     {
-                        //--------------Generate Token (JWT)---------------
-                        // Add Claims										
-                        List<Claim> UserClaims = new List<Claim>();
-                        UserClaims.Add(new Claim(ClaimTypes.NameIdentifier, userFromDb.Id));
-                        UserClaims.Add(new Claim(ClaimTypes.Name, userFromDb.UserName));
+                        // Generate Token
+                        var MyToken = await authRepo.GetTokenAsync(userFromDb);
 
-                        IList<string> UserRoles = await userManager.GetRolesAsync(userFromDb);
-                        foreach (var roleName in UserRoles)
-                            UserClaims.Add(new Claim(ClaimTypes.Role, roleName));
-
-                        UserClaims.Add(new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()));
-
-                        // Generate Key for Signature														
-                        SymmetricSecurityKey key
-                            = new(Encoding.UTF8.GetBytes(config["JWT:Key"]));
-
-                        SigningCredentials signCred
-                            = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-
-                        // Design Token
-                        JwtSecurityToken myToken = new JwtSecurityToken(
-                            issuer: config["JWT:Issuer"],
-                            audience: config["JWT:Audience"],
-                            expires: DateTime.Now.AddHours(1),
-                            claims: UserClaims,
-                            signingCredentials: signCred
-                        );
-
-                        // Generate Token and return it(as a string) in response
-                        return Ok(new
-                        {
-                            token = new JwtSecurityTokenHandler().WriteToken(myToken), // Token returned as a string
-                            expiration = DateTime.Now.AddHours(1) // or myToken.ValidTo
-                        });
-
+                        return Ok(new { token = MyToken });
                     }
                 }
                 ModelState.AddModelError("Username", "Username or Password Invalid.");
             }
             return BadRequest(ModelState);
+        }
+
+
+        [HttpPost("External-Login")]
+        public async Task<IActionResult> ExternalLogin(ExternalLoginDto model)
+        {
+            var payload = await GoogleJsonWebSignature.ValidateAsync(model.IdToken);
+
+            var email = payload.Email;
+
+            var user = await userManager.FindByEmailAsync(email);
+
+            if (user == null)
+            {
+                user = new ApplicationUser
+                {
+                    Email = email,
+                    EmailConfirmed = true
+                };
+
+                await userManager.CreateAsync(user);
+                await userManager.AddToRoleAsync(user, model.Role.ToString());
+            }
+
+            var token = await authRepo.GetTokenAsync(user);
+
+            return Ok(new { token });
         }
 
 

--- a/DataAccess/Configurations/ApplicationUserConfiguration.cs
+++ b/DataAccess/Configurations/ApplicationUserConfiguration.cs
@@ -8,11 +8,6 @@ namespace ELProject.DataAccess.Configurations
     {
         public void Configure(EntityTypeBuilder<ApplicationUser> builder)
         {
-            // 1. Properties
-            builder.Property(u => u.FullName)
-                .IsRequired()
-                .HasMaxLength(100);
-
             builder.Property(u => u.ProfileImage)
                 .HasMaxLength(500); // رابط الصورة قد يكون طويلاً
 

--- a/DataAccess/Repositories/Repos/AuthRepository.cs
+++ b/DataAccess/Repositories/Repos/AuthRepository.cs
@@ -1,0 +1,53 @@
+﻿using ELProject.Domain.Models;
+using ELProject.Shared;
+using ELProject.Shared.DTOs;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace ELProject.DataAccess.Repositories.Repos
+{
+    public class AuthRepository
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IConfiguration _config;
+
+        public AuthRepository(UserManager<ApplicationUser> userManager, IConfiguration config)
+        {
+            _userManager = userManager;
+            _config = config;
+        }
+
+        public async Task<string> GetTokenAsync(ApplicationUser user)
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.Id),
+                new Claim(ClaimTypes.Name, user.UserName!)
+            };
+
+            var UserRoles = await _userManager.GetRolesAsync(user);
+            foreach (var role in UserRoles)
+                claims.Add(new Claim(ClaimTypes.Role, role));
+
+            var key = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(_config["JWT:Key"]!));
+
+            var creds = new SigningCredentials(
+                key,
+                SecurityAlgorithms.HmacSha256);
+
+            var token = new JwtSecurityToken(
+                issuer: _config["JWT:Issuer"],
+                audience: _config["JWT:Audience"],
+                claims: claims,
+                expires: DateTime.UtcNow.AddHours(1),
+                signingCredentials: creds
+            );
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+    }
+}

--- a/ELProject.csproj
+++ b/ELProject.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />

--- a/Migrations/20260226023706_SecondaryInitialCreate.Designer.cs
+++ b/Migrations/20260226023706_SecondaryInitialCreate.Designer.cs
@@ -12,20 +12,20 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ELProject.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20260217211834_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20260226023706_SecondaryInitialCreate")]
+    partial class SecondaryInitialCreate
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.3")
+                .HasAnnotation("ProductVersion", "9.0.0")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("ELProject.Models.ApplicationUser", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.ApplicationUser", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
@@ -44,14 +44,9 @@ namespace ELProject.Migrations
                     b.Property<bool>("EmailConfirmed")
                         .HasColumnType("bit");
 
-                    b.Property<string>("FullName")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
-
-                    b.Property<string>("Gender")
+                    b.Property<int?>("Gender")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("JoinDate")
                         .ValueGeneratedOnAdd()
@@ -108,7 +103,7 @@ namespace ELProject.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
-            modelBuilder.Entity("ELProject.Models.Category", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Category", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -126,7 +121,7 @@ namespace ELProject.Migrations
                     b.ToTable("Categories");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Course", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Course", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -171,7 +166,7 @@ namespace ELProject.Migrations
                     b.ToTable("Courses");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Enrollment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Enrollment", b =>
                 {
                     b.Property<string>("UserId")
                         .HasColumnType("nvarchar(450)");
@@ -179,24 +174,44 @@ namespace ELProject.Migrations
                     b.Property<int>("CourseId")
                         .HasColumnType("int");
 
+                    b.Property<DateTime?>("CompletedAt")
+                        .HasColumnType("datetime2");
+
                     b.Property<DateTime>("EnrollDate")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
                         .HasDefaultValueSql("GETUTCDATE()");
+
+                    b.Property<int>("Id")
+                        .HasColumnType("int");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsCompleted")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
+                    b.Property<int?>("PaymentId")
+                        .HasColumnType("int");
+
+                    b.Property<decimal>("Progress")
+                        .HasPrecision(5, 2)
+                        .HasColumnType("decimal(5,2)");
+
                     b.HasKey("UserId", "CourseId");
 
                     b.HasIndex("CourseId");
 
+                    b.HasIndex("PaymentId")
+                        .IsUnique()
+                        .HasFilter("[PaymentId] IS NOT NULL");
+
                     b.ToTable("Enrollments");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Lesson", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Lesson", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -253,7 +268,7 @@ namespace ELProject.Migrations
                     b.ToTable("Lessons");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Payment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Payment", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -264,7 +279,7 @@ namespace ELProject.Migrations
                     b.Property<decimal>("Amount")
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<int?>("CourseId")
+                    b.Property<int>("CourseId")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedAt")
@@ -288,25 +303,37 @@ namespace ELProject.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("nvarchar(255)");
 
+                    b.Property<string>("PaymentIntentId")
+                        .HasMaxLength(255)
+                        .HasColumnType("nvarchar(255)");
+
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(20)
                         .HasColumnType("nvarchar(20)");
 
-                    b.Property<string>("UserId")
+                    b.Property<string>("StudentId")
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
+
+                    b.Property<DateTime>("UpdateTime")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("GETUTCDATE()");
 
                     b.HasKey("Id");
 
                     b.HasIndex("CourseId");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex("GatewayCheckoutSessionId")
+                        .IsUnique();
+
+                    b.HasIndex("StudentId");
 
                     b.ToTable("Payments");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Question", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Question", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -343,7 +370,36 @@ namespace ELProject.Migrations
                     b.ToTable("Questions");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Review", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Quiz", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("CourseId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("TimeLimitInMinutes")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("nvarchar(150)");
+
+                    b.Property<int>("TotalMarks")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CourseId");
+
+                    b.ToTable("Quizzes");
+                });
+
+            modelBuilder.Entity("ELProject.Domain.Models.Review", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -379,7 +435,7 @@ namespace ELProject.Migrations
                     b.ToTable("Reviews");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Section", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Section", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -402,7 +458,7 @@ namespace ELProject.Migrations
                     b.ToTable("Sections");
                 });
 
-            modelBuilder.Entity("ELProject.Models.StudentQuiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.StudentQuiz", b =>
                 {
                     b.Property<string>("UserId")
                         .HasColumnType("nvarchar(450)");
@@ -558,44 +614,15 @@ namespace ELProject.Migrations
                     b.ToTable("AspNetUserTokens", (string)null);
                 });
 
-            modelBuilder.Entity("Quiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Course", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("CourseId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("TimeLimitInMinutes")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasMaxLength(150)
-                        .HasColumnType("nvarchar(150)");
-
-                    b.Property<int>("TotalMarks")
-                        .HasColumnType("int");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CourseId");
-
-                    b.ToTable("Quizzes");
-                });
-
-            modelBuilder.Entity("ELProject.Models.Course", b =>
-                {
-                    b.HasOne("ELProject.Models.Category", "Category")
+                    b.HasOne("ELProject.Domain.Models.Category", "Category")
                         .WithMany("Courses")
                         .HasForeignKey("CategoryId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("CreatedCourses")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -606,15 +633,20 @@ namespace ELProject.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Enrollment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Enrollment", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Enrollments")
                         .HasForeignKey("CourseId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.Payment", "Payment")
+                        .WithOne("Enrollment")
+                        .HasForeignKey("ELProject.Domain.Models.Enrollment", "PaymentId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("Enrollments")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -622,17 +654,19 @@ namespace ELProject.Migrations
 
                     b.Navigation("Course");
 
+                    b.Navigation("Payment");
+
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Lesson", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Lesson", b =>
                 {
-                    b.HasOne("Quiz", "Quiz")
+                    b.HasOne("ELProject.Domain.Models.Quiz", "Quiz")
                         .WithMany()
                         .HasForeignKey("QuizId")
                         .OnDelete(DeleteBehavior.NoAction);
 
-                    b.HasOne("ELProject.Models.Section", "Section")
+                    b.HasOne("ELProject.Domain.Models.Section", "Section")
                         .WithMany("Lessons")
                         .HasForeignKey("SectionId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -643,27 +677,28 @@ namespace ELProject.Migrations
                     b.Navigation("Section");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Payment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Payment", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Payments")
                         .HasForeignKey("CourseId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "Student")
                         .WithMany("Payments")
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.NoAction)
+                        .HasForeignKey("StudentId")
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Course");
 
-                    b.Navigation("User");
+                    b.Navigation("Student");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Question", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Question", b =>
                 {
-                    b.HasOne("Quiz", "Quiz")
+                    b.HasOne("ELProject.Domain.Models.Quiz", "Quiz")
                         .WithMany("Questions")
                         .HasForeignKey("QuizId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -672,15 +707,26 @@ namespace ELProject.Migrations
                     b.Navigation("Quiz");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Review", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Quiz", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
+                        .WithMany("Quizzes")
+                        .HasForeignKey("CourseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Course");
+                });
+
+            modelBuilder.Entity("ELProject.Domain.Models.Review", b =>
+                {
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Reviews")
                         .HasForeignKey("CourseId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("Reviews")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.NoAction)
@@ -691,9 +737,9 @@ namespace ELProject.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Section", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Section", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Sections")
                         .HasForeignKey("CourseId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -702,15 +748,15 @@ namespace ELProject.Migrations
                     b.Navigation("Course");
                 });
 
-            modelBuilder.Entity("ELProject.Models.StudentQuiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.StudentQuiz", b =>
                 {
-                    b.HasOne("Quiz", "Quiz")
+                    b.HasOne("ELProject.Domain.Models.Quiz", "Quiz")
                         .WithMany("StudentQuizzes")
                         .HasForeignKey("QuizId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("StudentQuizzes")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -732,7 +778,7 @@ namespace ELProject.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
                 {
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -741,7 +787,7 @@ namespace ELProject.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -756,7 +802,7 @@ namespace ELProject.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -765,25 +811,14 @@ namespace ELProject.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
                 {
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Quiz", b =>
-                {
-                    b.HasOne("ELProject.Models.Course", "Course")
-                        .WithMany("Quizzes")
-                        .HasForeignKey("CourseId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Course");
-                });
-
-            modelBuilder.Entity("ELProject.Models.ApplicationUser", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.ApplicationUser", b =>
                 {
                     b.Navigation("CreatedCourses");
 
@@ -796,12 +831,12 @@ namespace ELProject.Migrations
                     b.Navigation("StudentQuizzes");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Category", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Category", b =>
                 {
                     b.Navigation("Courses");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Course", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Course", b =>
                 {
                     b.Navigation("Enrollments");
 
@@ -814,16 +849,21 @@ namespace ELProject.Migrations
                     b.Navigation("Sections");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Section", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Payment", b =>
                 {
-                    b.Navigation("Lessons");
+                    b.Navigation("Enrollment");
                 });
 
-            modelBuilder.Entity("Quiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Quiz", b =>
                 {
                     b.Navigation("Questions");
 
                     b.Navigation("StudentQuizzes");
+                });
+
+            modelBuilder.Entity("ELProject.Domain.Models.Section", b =>
+                {
+                    b.Navigation("Lessons");
                 });
 #pragma warning restore 612, 618
         }

--- a/Migrations/20260226023706_SecondaryInitialCreate.cs
+++ b/Migrations/20260226023706_SecondaryInitialCreate.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace ELProject.Migrations
 {
     /// <inheritdoc />
-    public partial class InitialCreate : Migration
+    public partial class SecondaryInitialCreate : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -30,9 +30,8 @@ namespace ELProject.Migrations
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    FullName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
                     ProfileImage = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
-                    Gender = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true),
+                    Gender = table.Column<int>(type: "int", maxLength: 20, nullable: true),
                     JoinDate = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
                     UserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
                     NormalizedUserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
@@ -205,60 +204,37 @@ namespace ELProject.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "Enrollments",
-                columns: table => new
-                {
-                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    CourseId = table.Column<int>(type: "int", nullable: false),
-                    EnrollDate = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
-                    IsCompleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Enrollments", x => new { x.UserId, x.CourseId });
-                    table.ForeignKey(
-                        name: "FK_Enrollments_AspNetUsers_UserId",
-                        column: x => x.UserId,
-                        principalTable: "AspNetUsers",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_Enrollments_Courses_CourseId",
-                        column: x => x.CourseId,
-                        principalTable: "Courses",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                });
-
-            migrationBuilder.CreateTable(
                 name: "Payments",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    CourseId = table.Column<int>(type: "int", nullable: true),
                     Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
                     Currency = table.Column<string>(type: "nchar(3)", fixedLength: true, maxLength: 3, nullable: false),
                     Gateway = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
                     GatewayCheckoutSessionId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    PaymentIntentId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
                     Status = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()")
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    UpdateTime = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    StudentId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CourseId = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_Payments", x => x.Id);
                     table.ForeignKey(
-                        name: "FK_Payments_AspNetUsers_UserId",
-                        column: x => x.UserId,
+                        name: "FK_Payments_AspNetUsers_StudentId",
+                        column: x => x.StudentId,
                         principalTable: "AspNetUsers",
-                        principalColumn: "Id");
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_Payments_Courses_CourseId",
                         column: x => x.CourseId,
                         principalTable: "Courses",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -329,6 +305,43 @@ namespace ELProject.Migrations
                         principalTable: "Courses",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Enrollments",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CourseId = table.Column<int>(type: "int", nullable: false),
+                    Id = table.Column<int>(type: "int", nullable: false),
+                    EnrollDate = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    IsCompleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    Progress = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    PaymentId = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Enrollments", x => new { x.UserId, x.CourseId });
+                    table.ForeignKey(
+                        name: "FK_Enrollments_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Enrollments_Courses_CourseId",
+                        column: x => x.CourseId,
+                        principalTable: "Courses",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Enrollments_Payments_PaymentId",
+                        column: x => x.PaymentId,
+                        principalTable: "Payments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -468,6 +481,13 @@ namespace ELProject.Migrations
                 column: "CourseId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_Enrollments_PaymentId",
+                table: "Enrollments",
+                column: "PaymentId",
+                unique: true,
+                filter: "[PaymentId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Lessons_QuizId",
                 table: "Lessons",
                 column: "QuizId");
@@ -483,9 +503,15 @@ namespace ELProject.Migrations
                 column: "CourseId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_Payments_UserId",
+                name: "IX_Payments_GatewayCheckoutSessionId",
                 table: "Payments",
-                column: "UserId");
+                column: "GatewayCheckoutSessionId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Payments_StudentId",
+                table: "Payments",
+                column: "StudentId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Questions_QuizId",
@@ -543,9 +569,6 @@ namespace ELProject.Migrations
                 name: "Lessons");
 
             migrationBuilder.DropTable(
-                name: "Payments");
-
-            migrationBuilder.DropTable(
                 name: "Questions");
 
             migrationBuilder.DropTable(
@@ -556,6 +579,9 @@ namespace ELProject.Migrations
 
             migrationBuilder.DropTable(
                 name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "Payments");
 
             migrationBuilder.DropTable(
                 name: "Sections");

--- a/Migrations/AppDbContextModelSnapshot.cs
+++ b/Migrations/AppDbContextModelSnapshot.cs
@@ -17,12 +17,12 @@ namespace ELProject.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.3")
+                .HasAnnotation("ProductVersion", "9.0.0")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("ELProject.Models.ApplicationUser", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.ApplicationUser", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
@@ -41,14 +41,9 @@ namespace ELProject.Migrations
                     b.Property<bool>("EmailConfirmed")
                         .HasColumnType("bit");
 
-                    b.Property<string>("FullName")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
-
-                    b.Property<string>("Gender")
+                    b.Property<int?>("Gender")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("JoinDate")
                         .ValueGeneratedOnAdd()
@@ -105,7 +100,7 @@ namespace ELProject.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
-            modelBuilder.Entity("ELProject.Models.Category", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Category", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -123,7 +118,7 @@ namespace ELProject.Migrations
                     b.ToTable("Categories");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Course", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Course", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -168,7 +163,7 @@ namespace ELProject.Migrations
                     b.ToTable("Courses");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Enrollment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Enrollment", b =>
                 {
                     b.Property<string>("UserId")
                         .HasColumnType("nvarchar(450)");
@@ -176,24 +171,44 @@ namespace ELProject.Migrations
                     b.Property<int>("CourseId")
                         .HasColumnType("int");
 
+                    b.Property<DateTime?>("CompletedAt")
+                        .HasColumnType("datetime2");
+
                     b.Property<DateTime>("EnrollDate")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
                         .HasDefaultValueSql("GETUTCDATE()");
+
+                    b.Property<int>("Id")
+                        .HasColumnType("int");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsCompleted")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
+                    b.Property<int?>("PaymentId")
+                        .HasColumnType("int");
+
+                    b.Property<decimal>("Progress")
+                        .HasPrecision(5, 2)
+                        .HasColumnType("decimal(5,2)");
+
                     b.HasKey("UserId", "CourseId");
 
                     b.HasIndex("CourseId");
 
+                    b.HasIndex("PaymentId")
+                        .IsUnique()
+                        .HasFilter("[PaymentId] IS NOT NULL");
+
                     b.ToTable("Enrollments");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Lesson", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Lesson", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -250,7 +265,7 @@ namespace ELProject.Migrations
                     b.ToTable("Lessons");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Payment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Payment", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -261,7 +276,7 @@ namespace ELProject.Migrations
                     b.Property<decimal>("Amount")
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<int?>("CourseId")
+                    b.Property<int>("CourseId")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedAt")
@@ -285,25 +300,37 @@ namespace ELProject.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("nvarchar(255)");
 
+                    b.Property<string>("PaymentIntentId")
+                        .HasMaxLength(255)
+                        .HasColumnType("nvarchar(255)");
+
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(20)
                         .HasColumnType("nvarchar(20)");
 
-                    b.Property<string>("UserId")
+                    b.Property<string>("StudentId")
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
+
+                    b.Property<DateTime>("UpdateTime")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("GETUTCDATE()");
 
                     b.HasKey("Id");
 
                     b.HasIndex("CourseId");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex("GatewayCheckoutSessionId")
+                        .IsUnique();
+
+                    b.HasIndex("StudentId");
 
                     b.ToTable("Payments");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Question", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Question", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -340,7 +367,36 @@ namespace ELProject.Migrations
                     b.ToTable("Questions");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Review", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Quiz", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("CourseId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("TimeLimitInMinutes")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("nvarchar(150)");
+
+                    b.Property<int>("TotalMarks")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CourseId");
+
+                    b.ToTable("Quizzes");
+                });
+
+            modelBuilder.Entity("ELProject.Domain.Models.Review", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -376,7 +432,7 @@ namespace ELProject.Migrations
                     b.ToTable("Reviews");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Section", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Section", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -399,7 +455,7 @@ namespace ELProject.Migrations
                     b.ToTable("Sections");
                 });
 
-            modelBuilder.Entity("ELProject.Models.StudentQuiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.StudentQuiz", b =>
                 {
                     b.Property<string>("UserId")
                         .HasColumnType("nvarchar(450)");
@@ -555,44 +611,15 @@ namespace ELProject.Migrations
                     b.ToTable("AspNetUserTokens", (string)null);
                 });
 
-            modelBuilder.Entity("Quiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Course", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("CourseId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("TimeLimitInMinutes")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasMaxLength(150)
-                        .HasColumnType("nvarchar(150)");
-
-                    b.Property<int>("TotalMarks")
-                        .HasColumnType("int");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CourseId");
-
-                    b.ToTable("Quizzes");
-                });
-
-            modelBuilder.Entity("ELProject.Models.Course", b =>
-                {
-                    b.HasOne("ELProject.Models.Category", "Category")
+                    b.HasOne("ELProject.Domain.Models.Category", "Category")
                         .WithMany("Courses")
                         .HasForeignKey("CategoryId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("CreatedCourses")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -603,15 +630,20 @@ namespace ELProject.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Enrollment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Enrollment", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Enrollments")
                         .HasForeignKey("CourseId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.Payment", "Payment")
+                        .WithOne("Enrollment")
+                        .HasForeignKey("ELProject.Domain.Models.Enrollment", "PaymentId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("Enrollments")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -619,17 +651,19 @@ namespace ELProject.Migrations
 
                     b.Navigation("Course");
 
+                    b.Navigation("Payment");
+
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Lesson", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Lesson", b =>
                 {
-                    b.HasOne("Quiz", "Quiz")
+                    b.HasOne("ELProject.Domain.Models.Quiz", "Quiz")
                         .WithMany()
                         .HasForeignKey("QuizId")
                         .OnDelete(DeleteBehavior.NoAction);
 
-                    b.HasOne("ELProject.Models.Section", "Section")
+                    b.HasOne("ELProject.Domain.Models.Section", "Section")
                         .WithMany("Lessons")
                         .HasForeignKey("SectionId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -640,27 +674,28 @@ namespace ELProject.Migrations
                     b.Navigation("Section");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Payment", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Payment", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Payments")
                         .HasForeignKey("CourseId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "Student")
                         .WithMany("Payments")
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.NoAction)
+                        .HasForeignKey("StudentId")
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Course");
 
-                    b.Navigation("User");
+                    b.Navigation("Student");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Question", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Question", b =>
                 {
-                    b.HasOne("Quiz", "Quiz")
+                    b.HasOne("ELProject.Domain.Models.Quiz", "Quiz")
                         .WithMany("Questions")
                         .HasForeignKey("QuizId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -669,15 +704,26 @@ namespace ELProject.Migrations
                     b.Navigation("Quiz");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Review", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Quiz", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
+                        .WithMany("Quizzes")
+                        .HasForeignKey("CourseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Course");
+                });
+
+            modelBuilder.Entity("ELProject.Domain.Models.Review", b =>
+                {
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Reviews")
                         .HasForeignKey("CourseId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("Reviews")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.NoAction)
@@ -688,9 +734,9 @@ namespace ELProject.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Section", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Section", b =>
                 {
-                    b.HasOne("ELProject.Models.Course", "Course")
+                    b.HasOne("ELProject.Domain.Models.Course", "Course")
                         .WithMany("Sections")
                         .HasForeignKey("CourseId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -699,15 +745,15 @@ namespace ELProject.Migrations
                     b.Navigation("Course");
                 });
 
-            modelBuilder.Entity("ELProject.Models.StudentQuiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.StudentQuiz", b =>
                 {
-                    b.HasOne("Quiz", "Quiz")
+                    b.HasOne("ELProject.Domain.Models.Quiz", "Quiz")
                         .WithMany("StudentQuizzes")
                         .HasForeignKey("QuizId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", "User")
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", "User")
                         .WithMany("StudentQuizzes")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -729,7 +775,7 @@ namespace ELProject.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
                 {
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -738,7 +784,7 @@ namespace ELProject.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -753,7 +799,7 @@ namespace ELProject.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -762,25 +808,14 @@ namespace ELProject.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
                 {
-                    b.HasOne("ELProject.Models.ApplicationUser", null)
+                    b.HasOne("ELProject.Domain.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Quiz", b =>
-                {
-                    b.HasOne("ELProject.Models.Course", "Course")
-                        .WithMany("Quizzes")
-                        .HasForeignKey("CourseId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Course");
-                });
-
-            modelBuilder.Entity("ELProject.Models.ApplicationUser", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.ApplicationUser", b =>
                 {
                     b.Navigation("CreatedCourses");
 
@@ -793,12 +828,12 @@ namespace ELProject.Migrations
                     b.Navigation("StudentQuizzes");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Category", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Category", b =>
                 {
                     b.Navigation("Courses");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Course", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Course", b =>
                 {
                     b.Navigation("Enrollments");
 
@@ -811,16 +846,21 @@ namespace ELProject.Migrations
                     b.Navigation("Sections");
                 });
 
-            modelBuilder.Entity("ELProject.Models.Section", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Payment", b =>
                 {
-                    b.Navigation("Lessons");
+                    b.Navigation("Enrollment");
                 });
 
-            modelBuilder.Entity("Quiz", b =>
+            modelBuilder.Entity("ELProject.Domain.Models.Quiz", b =>
                 {
                     b.Navigation("Questions");
 
                     b.Navigation("StudentQuizzes");
+                });
+
+            modelBuilder.Entity("ELProject.Domain.Models.Section", b =>
+                {
+                    b.Navigation("Lessons");
                 });
 #pragma warning restore 612, 618
         }

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,16 @@
 using ELProject.DataAccess;
+using ELProject.DataAccess.Seed;
+using ELProject.Domain.Models;
 using ELProject.Shared;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
@@ -15,6 +23,43 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 
 builder.Services.AddScoped<IFileStorageService, FileStorageService>();
 
+builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
+    .AddEntityFrameworkStores<AppDbContext>();
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.SaveToken = true;
+    options.RequireHttpsMetadata = false;
+    options.TokenValidationParameters = new TokenValidationParameters()
+    {
+        ValidateAudience = true,
+        ValidAudience = builder.Configuration["JWT:Audience"],
+        ValidateIssuer = true,
+        ValidIssuer = builder.Configuration["JWT:Issuer"],
+        IssuerSigningKey =
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["JWT:Key"]))
+    };
+}).AddGoogle(options =>
+{
+    options.ClientId = builder.Configuration["Authentication:Google:ClientId"];
+    options.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"];
+});
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod();
+    });
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -23,14 +68,13 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
-// Run one time
-/*using (var scope = app.Services.CreateScope())
+using (var scope = app.Services.CreateScope())
 {
     var roleManager = scope.ServiceProvider
         .GetRequiredService<RoleManager<IdentityRole>>();
 
     await RoleSeeder.SeedRolesAsync(roleManager);
-}*/
+}
 
 app.UseAuthorization();
 

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -13,7 +13,7 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
       "applicationUrl": "https://localhost:7100;http://localhost:5241",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Shared/DTOs/ExternalLoginDto.cs
+++ b/Shared/DTOs/ExternalLoginDto.cs
@@ -1,0 +1,14 @@
+﻿using ELProject.Domain.Enums;
+using System.ComponentModel.DataAnnotations;
+
+namespace ELProject.Shared.DTOs
+{
+    public class ExternalLoginDto
+    {
+        public string IdToken { get; set; } = null!;
+
+        [Required]
+        [EnumDataType(typeof(UserRole), ErrorMessage = "Invalid role selected.")]
+        public string Role { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
I removed InitialCreate Migration because it was contain on:
- FullName that we have already and removed.
- New edit for some datatypes like Role from string to enum and Gender from string to enum
- (Main Reason) it was have a configration for FullName Property in ApplicationUser Class
Create a new one called SecondaryInitialCreate